### PR TITLE
Update marketing duration calc

### DIFF
--- a/src/components/models/MarketingChannelsForm.tsx
+++ b/src/components/models/MarketingChannelsForm.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { v4 as uuidv4 } from 'uuid';
-import { MarketingSetup, MarketingChannelItem, ModelAssumptions } from '@/types/models';
+import { MarketingSetup, MarketingChannelItem, ModelAssumptions, ModelMetadata } from '@/types/models';
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
@@ -21,6 +21,7 @@ interface MarketingChannelsFormProps {
   marketingSetup: MarketingSetup;
   updateAssumptions: (updatedFields: Partial<ModelAssumptions>) => void;
   modelTimeUnit: 'Week' | 'Month';
+  metadata?: ModelMetadata;
 }
 
 const defaultChannelTypes = [
@@ -37,10 +38,11 @@ const defaultChannelTypes = [
   "Custom",
 ];
 
-export const MarketingChannelsForm: React.FC<MarketingChannelsFormProps> = ({ 
-  marketingSetup, 
+export const MarketingChannelsForm: React.FC<MarketingChannelsFormProps> = ({
+  marketingSetup,
   updateAssumptions,
-  modelTimeUnit
+  modelTimeUnit,
+  metadata
 }) => {
   const [allocationMode, setAllocationMode] = useState<'channels' | 'highLevel'>(
       marketingSetup.allocationMode || 'channels'
@@ -144,13 +146,18 @@ export const MarketingChannelsForm: React.FC<MarketingChannelsFormProps> = ({
       budgetApplication: allocationMode === 'highLevel' ? budgetApplication : undefined,
       spreadDuration: allocationMode === 'highLevel' && budgetApplication === 'spreadCustom' ? spreadDuration : undefined,
     };
-     console.log("Saving marketing setup:", currentInternalSetup);
-     updateAssumptions({ marketing: currentInternalSetup });
+    updateAssumptions({ marketing: currentInternalSetup });
   };
 
   const totalWeeklyChannelBudget = channels.reduce((sum, ch) => sum + (ch.weeklyBudget || 0), 0);
 
-  const getModelDuration = () => modelTimeUnit === 'Week' ? (marketingSetup.channels?.length > 0 ? 12 : 12) : 12;
+  const getModelDuration = () => {
+    if (modelTimeUnit === 'Week') {
+      return metadata?.weeks ?? 12;
+    }
+    // Fallback to 12 months for models without explicit month duration
+    return (metadata as any)?.months ?? 12;
+  };
 
   return (
     <Card>

--- a/src/pages/models/FinancialModelDetail.tsx
+++ b/src/pages/models/FinancialModelDetail.tsx
@@ -354,13 +354,14 @@ const FinancialModelDetail = () => {
            <ModelOverview model={model as any} projectId={projectId} /> 
          </TabsContent>
 
-         <TabsContent value="marketing">
-           <MarketingChannelsForm 
-             marketingSetup={memoizedMarketingSetup} 
-             updateAssumptions={updateModelAssumptions} 
-             modelTimeUnit={isWeeklyEvent ? 'Week' : 'Month'} 
-           />
-         </TabsContent>
+           <TabsContent value="marketing">
+            <MarketingChannelsForm
+              marketingSetup={memoizedMarketingSetup}
+              updateAssumptions={updateModelAssumptions}
+              modelTimeUnit={isWeeklyEvent ? 'Week' : 'Month'}
+              metadata={memoizedMetadata}
+            />
+          </TabsContent>
 
          <TabsContent value="financial-matrix">
              <Card>


### PR DESCRIPTION
## Summary
- calculate marketing budget duration from model metadata
- pass metadata through FinancialModelDetail to MarketingChannelsForm
- remove console log from marketing budget form

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_b_6858fcc72d2483209339bc7cc2da36e1