### PR TITLE
Fix dashboard navigation

### DIFF
--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -12,7 +12,9 @@ interface SidebarProps {
 
 const Sidebar: React.FC<SidebarProps> = ({ isCollapsed, toggleSidebar }) => {
   const navItems = [
-    { name: "Dashboard", path: "/dashboard", icon: Home },
+    // The Dashboard route is the index route at "/" so the sidebar link should
+    // navigate to the root path
+    { name: "Dashboard", path: "/", icon: Home },
     { name: "Projects", path: "/projects", icon: FolderKanban },
     // Add other top-level sections if needed
     // { name: "Performance", path: "/performance", icon: LineChart },


### PR DESCRIPTION
## Summary
- fix sidebar link so Dashboard leads to root path

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_6858fcc428a883209a262f38447a3141