### PR TITLE
Emphasize installing dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,17 @@ git clone <YOUR_GIT_URL>
 cd <YOUR_PROJECT_NAME>
 
 # Step 3: Install the necessary dependencies.
-npm i
+# You can use either npm or pnpm for this step.
+npm install
+# or
+pnpm install
+
+# **Important:** Always run `npm install` (or `pnpm install`) before using
+# `npm run dev`, `npm run build`, or `npm run lint`. These commands depend on
+# the packages installed in `node_modules` and will fail if the dependencies are
+# missing.
+# The included npm scripts run a small pre-check and will print a helpful
+# message if `node_modules` is absent.
 
 # Step 4: Start the development server with auto-reloading and an instant preview.
 npm run dev

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
+    "predev": "node scripts/check-deps.cjs",
+    "prebuild": "node scripts/check-deps.cjs",
+    "prelint": "node scripts/check-deps.cjs",
     "dev": "vite",
     "build": "vite build",
     "build:dev": "vite build --mode development",

--- a/scripts/check-deps.cjs
+++ b/scripts/check-deps.cjs
@@ -1,0 +1,5 @@
+const fs = require('fs');
+if (!fs.existsSync('node_modules')) {
+  console.error('Dependencies not installed. Please run "npm install" or "pnpm install" before running this command.');
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- mention running `npm install` or `pnpm install` before using dev/build/lint scripts
- add a pre-check script to make this requirement explicit

## Testing
- `npm run lint` *(fails: dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_b_6858fba6bb408320a8cf0a577d5311c3