### PR TITLE
Add TypeScript typecheck script

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,3 +71,13 @@ Yes it is!
 To connect a domain, navigate to Project > Settings > Domains and click Connect Domain.
 
 Read more here: [Setting up a custom domain](https://docs.lovable.dev/tips-tricks/custom-domain#step-by-step-guide)
+
+## Type checking
+
+Run the TypeScript compiler in check mode to verify the project builds without emitting files:
+
+```sh
+npm run typecheck
+```
+
+This executes `tsc --noEmit` using the settings defined in `tsconfig.json`.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",


### PR DESCRIPTION
## Summary
- add `typecheck` npm script that runs `tsc --noEmit`
- document how to run the type checker in the README

## Testing
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_b_6858fb956b2c83209e2aa96b592cd026