### PR TITLE
Add TrendDataPoint interface and apply typed arrays

### DIFF
--- a/src/components/models/CategoryBreakdown.tsx
+++ b/src/components/models/CategoryBreakdown.tsx
@@ -21,11 +21,12 @@ import { CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { formatCurrency } from "@/lib/utils";
+import { TrendDataPoint } from "@/types/trends";
 
 interface CategoryBreakdownProps {
   model: FinancialModel;
-  revenueTrendData: any[]; // Add prop for full revenue trend data
-  costTrendData: any[]; // Add prop for full cost trend data
+  revenueTrendData: TrendDataPoint[]; // Add prop for full revenue trend data
+  costTrendData: TrendDataPoint[]; // Add prop for full cost trend data
 }
 
 // Define consistent colors, adding Marketing Budget

--- a/src/components/models/CostTrends.tsx
+++ b/src/components/models/CostTrends.tsx
@@ -12,6 +12,7 @@ import {
 } from "recharts";
 import FinancialMatrix from "./FinancialMatrix";
 import { MarketingSetup, ModelMetadata, GrowthModel } from "@/types/models";
+import { TrendDataPoint } from "@/types/trends";
 
 interface CostTrendsProps {
   costs: CostAssumption[];
@@ -19,7 +20,7 @@ interface CostTrendsProps {
   metadata?: ModelMetadata;
   growthModel?: GrowthModel;
   model: FinancialModel;
-  onUpdateCostData: (data: any[]) => void;
+  onUpdateCostData: (data: TrendDataPoint[]) => void;
 }
 
 const CostTrends = ({ 
@@ -35,10 +36,10 @@ const CostTrends = ({
   const timeUnit = isWeeklyEvent ? "Week" : "Month";
   
   // Memoize the cost data calculation
-  const costData = useMemo(() => {
+  const costData: TrendDataPoint[] = useMemo(() => {
     console.log("[CostTrends] Recalculating costData...");
     try {
-      const data = [];
+      const data: TrendDataPoint[] = [];
       // Use passed props directly
       if (!costs || !metadata) return []; 
       
@@ -50,7 +51,7 @@ const CostTrends = ({
         const weeks = Math.min(metadata.weeks || 12, timePoints);
         
         for (let week = 1; week <= weeks; week++) {
-          const point: any = { point: `Week ${week}` };
+          const point: TrendDataPoint = { point: `Week ${week}` };
           let weeklyTotal = 0;
           
           // Get week 1 attendance and current attendance
@@ -159,8 +160,8 @@ const CostTrends = ({
          const months = timePoints;
          const modelDuration = duration; // Use calculated model duration (likely 12 months)
 
-         for (let month = 1; month <= months; month++) {
-           const point: any = { point: `Month ${month}` };
+           for (let month = 1; month <= months; month++) {
+           const point: TrendDataPoint = { point: `Month ${month}` };
            let monthlyTotal = 0;
            // Add regular costs
            costs.forEach(cost => {

--- a/src/components/models/FinancialMatrix.tsx
+++ b/src/components/models/FinancialMatrix.tsx
@@ -1,10 +1,11 @@
 import { useState, useMemo } from "react";
 import { FinancialModel } from "@/lib/db";
 import { formatCurrency } from "@/lib/utils";
+import { TrendDataPoint } from "@/types/trends";
 
 interface FinancialMatrixProps {
   model: FinancialModel;
-  trendData: any[];
+  trendData: TrendDataPoint[];
   revenueData?: boolean;
   costData?: boolean;
   combinedView?: boolean;

--- a/src/components/models/RevenueTrends.tsx
+++ b/src/components/models/RevenueTrends.tsx
@@ -11,11 +11,12 @@ import {
   ResponsiveContainer,
 } from "recharts";
 import FinancialMatrix from "./FinancialMatrix";
+import { TrendDataPoint } from "@/types/trends";
 
 interface RevenueTrendsProps {
   model: FinancialModel;
-  combinedData?: any[];
-  setCombinedData: (data: any[]) => void;
+  combinedData?: TrendDataPoint[];
+  setCombinedData: (data: TrendDataPoint[]) => void;
 }
 
 const RevenueTrends = ({ model, combinedData, setCombinedData }: RevenueTrendsProps) => {
@@ -23,10 +24,10 @@ const RevenueTrends = ({ model, combinedData, setCombinedData }: RevenueTrendsPr
   const isWeeklyEvent = model.assumptions.metadata?.type === "WeeklyEvent";
   const timeUnit = isWeeklyEvent ? "Week" : "Month";
 
-  const trendData = useMemo(() => {
+  const trendData: TrendDataPoint[] = useMemo(() => {
     console.log("[RevenueTrends] Recalculating trendData...");
     try {
-      const data = [];
+      const data: TrendDataPoint[] = [];
       if (!model?.assumptions?.revenue || !model?.assumptions?.metadata) return [];
       
       const isWeeklyEvent = model.assumptions.metadata?.type === "WeeklyEvent";
@@ -47,7 +48,7 @@ const RevenueTrends = ({ model, combinedData, setCombinedData }: RevenueTrendsPr
         let cumulativeTotal = 0;
         
         for (let week = 1; week <= weeks; week++) {
-          const point: any = { point: `Week ${week}` };
+          const point: TrendDataPoint = { point: `Week ${week}` };
           
           let currentAttendance = metadata.initialWeeklyAttendance || 0;
           if (week > 1 && metadata.growth) { 
@@ -108,7 +109,7 @@ const RevenueTrends = ({ model, combinedData, setCombinedData }: RevenueTrendsPr
         let cumulativeTotal = 0;
         
         for (let month = 1; month <= months; month++) {
-          const point: any = { point: `Month ${month}` };
+          const point: TrendDataPoint = { point: `Month ${month}` };
           let totalRevenue = 0;
           revenueStreams.forEach(stream => {
             let streamRevenue = stream.value;

--- a/src/pages/models/FinancialModelDetail.tsx
+++ b/src/pages/models/FinancialModelDetail.tsx
@@ -28,6 +28,7 @@ import { calculateTotalRevenue, calculateTotalCosts } from "@/lib/financialCalcu
 import { ModelOverview } from "@/components/models/ModelOverview";
 import { MarketingChannelsForm } from "@/components/models/MarketingChannelsForm";
 import { ModelAssumptions, MarketingSetup, RevenueStream, CostCategory } from "@/types/models";
+import { TrendDataPoint } from "@/types/trends";
 
 const FinancialModelDetail = () => {
   const { projectId, modelId } = useParams<{ projectId: string; modelId: string }>();
@@ -37,9 +38,9 @@ const FinancialModelDetail = () => {
   const [loading, setLoading] = useState(true);
   const [model, setModel] = useState<FinancialModel | null>(null);
   const { loadProjectById, currentProject, setCurrentProject } = useStore();
-  const [revenueData, setRevenueData] = useState<any[]>([]);
-  const [costData, setCostData] = useState<any[]>([]);
-  const [combinedFinancialData, setCombinedFinancialData] = useState<any[]>([]);
+  const [revenueData, setRevenueData] = useState<TrendDataPoint[]>([]);
+  const [costData, setCostData] = useState<TrendDataPoint[]>([]);
+  const [combinedFinancialData, setCombinedFinancialData] = useState<TrendDataPoint[]>([]);
   const [isFinancialDataReady, setIsFinancialDataReady] = useState<boolean>(false);
   
   // Memoize assumption props (call unconditionally)
@@ -121,7 +122,7 @@ const FinancialModelDetail = () => {
     }
     
     try {
-      const periodMap = new Map<string, any>();
+      const periodMap = new Map<string, TrendDataPoint>();
       
       // Process revenue first
       revenueData.forEach(revPeriod => {

--- a/src/types/trends.ts
+++ b/src/types/trends.ts
@@ -1,0 +1,11 @@
+export interface TrendDataPoint {
+  point: string;
+  attendance?: number;
+  revenue?: number;
+  cumulativeRevenue?: number;
+  costs?: number;
+  cumulativeCosts?: number;
+  profit?: number;
+  cumulativeProfit?: number;
+  [key: string]: number | string | undefined;
+}


### PR DESCRIPTION
## Summary
- introduce `TrendDataPoint` interface describing trend data shape
- apply `TrendDataPoint[]` to RevenueTrends, CostTrends and FinancialMatrix
- type props in CategoryBreakdown and pages using new interface
- update revenue and cost trend calculations to create typed data objects

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_b_6858fb9316008320846142341d6a0aa3