### PR TITLE
Address data inconsistency in trend calculations

### DIFF
--- a/src/components/models/CategoryBreakdown.tsx
+++ b/src/components/models/CategoryBreakdown.tsx
@@ -21,11 +21,12 @@ import { CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { formatCurrency } from "@/lib/utils";
+import { TrendDataPoint } from "@/types/trends";
 
 interface CategoryBreakdownProps {
   model: FinancialModel;
-  revenueTrendData: any[]; // Add prop for full revenue trend data
-  costTrendData: any[]; // Add prop for full cost trend data
+  revenueTrendData: TrendDataPoint[]; // Add prop for full revenue trend data
+  costTrendData: TrendDataPoint[]; // Add prop for full cost trend data
 }
 
 // Define consistent colors, adding Marketing Budget

--- a/src/components/models/CostTrends.tsx
+++ b/src/components/models/CostTrends.tsx
@@ -12,6 +12,7 @@ import {
 } from "recharts";
 import FinancialMatrix from "./FinancialMatrix";
 import { MarketingSetup, ModelMetadata, GrowthModel } from "@/types/models";
+import { TrendDataPoint } from "@/types/trends";
 
 interface CostTrendsProps {
   costs: CostAssumption[];
@@ -19,7 +20,7 @@ interface CostTrendsProps {
   metadata?: ModelMetadata;
   growthModel?: GrowthModel;
   model: FinancialModel;
-  onUpdateCostData: (data: any[]) => void;
+  onUpdateCostData: (data: TrendDataPoint[]) => void;
 }
 
 const CostTrends = ({ 
@@ -35,9 +36,9 @@ const CostTrends = ({
   const timeUnit = isWeeklyEvent ? "Week" : "Month";
   
   // Memoize the cost data calculation
-  const costData = useMemo(() => {
+  const costData: TrendDataPoint[] = useMemo(() => {
     try {
-      const data = [];
+      const data: TrendDataPoint[] = [];
       // Use passed props directly
       if (!costs || !metadata) return []; 
       
@@ -49,7 +50,7 @@ const CostTrends = ({
         const weeks = Math.min(metadata.weeks || 12, timePoints);
         
         for (let week = 1; week <= weeks; week++) {
-          const point: any = { point: `Week ${week}` };
+          const point: TrendDataPoint = { point: `Week ${week}` };
           let weeklyTotal = 0;
           
           // Get week 1 attendance and current attendance
@@ -157,7 +158,7 @@ const CostTrends = ({
          const modelDuration = duration; // Use calculated model duration (likely 12 months)
 
          for (let month = 1; month <= months; month++) {
-           const point: any = { point: `Month ${month}` };
+           const point: TrendDataPoint = { point: `Month ${month}` };
            let monthlyTotal = 0;
            // Add regular costs
            costs.forEach(cost => {
@@ -208,12 +209,12 @@ const CostTrends = ({
              monthlyTotal += periodMarketingCost;
            }
            
-           point.total = Math.ceil(monthlyTotal);
-           
+           point.costs = Math.ceil(monthlyTotal);
+
            if (month === 1) {
-             point.cumulativeTotal = Math.ceil(monthlyTotal);
+             point.cumulativeCosts = Math.ceil(monthlyTotal);
            } else {
-             point.cumulativeTotal = Math.ceil(data[month - 2].cumulativeTotal + monthlyTotal);
+             point.cumulativeCosts = Math.ceil(data[month - 2].cumulativeCosts + monthlyTotal);
            }
            
            data.push(point);

--- a/src/components/models/FinancialMatrix.tsx
+++ b/src/components/models/FinancialMatrix.tsx
@@ -1,10 +1,11 @@
 import { useState, useMemo } from "react";
 import { FinancialModel } from "@/lib/db";
 import { formatCurrency } from "@/lib/utils";
+import { TrendDataPoint } from "@/types/trends";
 
 interface FinancialMatrixProps {
   model: FinancialModel;
-  trendData: any[];
+  trendData: TrendDataPoint[];
   revenueData?: boolean;
   costData?: boolean;
   combinedView?: boolean;

--- a/src/components/models/RevenueTrends.tsx
+++ b/src/components/models/RevenueTrends.tsx
@@ -11,11 +11,12 @@ import {
   ResponsiveContainer,
 } from "recharts";
 import FinancialMatrix from "./FinancialMatrix";
+import { TrendDataPoint } from "@/types/trends";
 
 interface RevenueTrendsProps {
   model: FinancialModel;
-  combinedData?: any[];
-  setCombinedData: (data: any[]) => void;
+  combinedData?: TrendDataPoint[];
+  setCombinedData: (data: TrendDataPoint[]) => void;
 }
 
 const RevenueTrends = ({ model, combinedData, setCombinedData }: RevenueTrendsProps) => {
@@ -23,9 +24,9 @@ const RevenueTrends = ({ model, combinedData, setCombinedData }: RevenueTrendsPr
   const isWeeklyEvent = model.assumptions.metadata?.type === "WeeklyEvent";
   const timeUnit = isWeeklyEvent ? "Week" : "Month";
 
-  const trendData = useMemo(() => {
+  const trendData: TrendDataPoint[] = useMemo(() => {
     try {
-      const data = [];
+      const data: TrendDataPoint[] = [];
       if (!model?.assumptions?.revenue || !model?.assumptions?.metadata) return [];
       
       const isWeeklyEvent = model.assumptions.metadata?.type === "WeeklyEvent";
@@ -46,7 +47,7 @@ const RevenueTrends = ({ model, combinedData, setCombinedData }: RevenueTrendsPr
         let cumulativeTotal = 0;
         
         for (let week = 1; week <= weeks; week++) {
-          const point: any = { point: `Week ${week}` };
+          const point: TrendDataPoint = { point: `Week ${week}` };
           
           let currentAttendance = metadata.initialWeeklyAttendance || 0;
           if (week > 1 && metadata.growth) { 
@@ -107,7 +108,7 @@ const RevenueTrends = ({ model, combinedData, setCombinedData }: RevenueTrendsPr
         let cumulativeTotal = 0;
         
         for (let month = 1; month <= months; month++) {
-          const point: any = { point: `Month ${month}` };
+          const point: TrendDataPoint = { point: `Month ${month}` };
           let totalRevenue = 0;
           revenueStreams.forEach(stream => {
             let streamRevenue = stream.value;
@@ -124,9 +125,9 @@ const RevenueTrends = ({ model, combinedData, setCombinedData }: RevenueTrendsPr
             totalRevenue += streamRevenue;
           });
           
-          point.total = Math.ceil(totalRevenue);
+          point.revenue = Math.ceil(totalRevenue);
           cumulativeTotal += totalRevenue;
-          point.cumulativeTotal = Math.ceil(cumulativeTotal);
+          point.cumulativeRevenue = Math.ceil(cumulativeTotal);
           data.push(point);
         }
       }

--- a/src/pages/models/FinancialModelDetail.tsx
+++ b/src/pages/models/FinancialModelDetail.tsx
@@ -28,6 +28,7 @@ import { calculateTotalRevenue, calculateTotalCosts } from "@/lib/financialCalcu
 import { ModelOverview } from "@/components/models/ModelOverview";
 import { MarketingChannelsForm } from "@/components/models/MarketingChannelsForm";
 import { ModelAssumptions, MarketingSetup, RevenueStream, CostCategory } from "@/types/models";
+import { TrendDataPoint } from "@/types/trends";
 
 const FinancialModelDetail = () => {
   const { projectId, modelId } = useParams<{ projectId: string; modelId: string }>();
@@ -37,9 +38,9 @@ const FinancialModelDetail = () => {
   const [loading, setLoading] = useState(true);
   const [model, setModel] = useState<FinancialModel | null>(null);
   const { loadProjectById, currentProject, setCurrentProject } = useStore();
-  const [revenueData, setRevenueData] = useState<any[]>([]);
-  const [costData, setCostData] = useState<any[]>([]);
-  const [combinedFinancialData, setCombinedFinancialData] = useState<any[]>([]);
+  const [revenueData, setRevenueData] = useState<TrendDataPoint[]>([]);
+  const [costData, setCostData] = useState<TrendDataPoint[]>([]);
+  const [combinedFinancialData, setCombinedFinancialData] = useState<TrendDataPoint[]>([]);
   const [isFinancialDataReady, setIsFinancialDataReady] = useState<boolean>(false);
   
   // Memoize assumption props (call unconditionally)
@@ -114,7 +115,7 @@ const FinancialModelDetail = () => {
     }
     
     try {
-      const periodMap = new Map<string, any>();
+      const periodMap = new Map<string, TrendDataPoint>();
       
       // Process revenue first
       revenueData.forEach(revPeriod => {
@@ -144,8 +145,8 @@ const FinancialModelDetail = () => {
       // --- Recalculate Profit and Cumulative Profit --- 
       let cumulativeProfit = 0;
       combined = combined.map(period => {
-          const revenue = period.revenue || period.total || 0; // Handle different keys if necessary
-          const costs = period.costs || period.total || 0; // Handle different keys
+          const revenue = period.revenue || 0;
+          const costs = period.costs || 0;
           const profit = revenue - costs;
           cumulativeProfit += profit;
           

--- a/src/types/trends.ts
+++ b/src/types/trends.ts
@@ -1,0 +1,11 @@
+export interface TrendDataPoint {
+  point: string;
+  attendance?: number;
+  revenue?: number;
+  cumulativeRevenue?: number;
+  costs?: number;
+  cumulativeCosts?: number;
+  profit?: number;
+  cumulativeProfit?: number;
+  [key: string]: number | string | undefined;
+}


### PR DESCRIPTION
## Summary
- add new `TrendDataPoint` interface
- type trend calculations with `TrendDataPoint`
- use `revenue` and `costs` consistently across trends
- simplify profit calculation logic in financial model detail

## Testing
- `npm run typecheck`
- `npm run lint` *(fails: 27 problems)*

------
https://chatgpt.com/codex/tasks/task_b_6859064e79788320b31214f5328146c0