### PR TITLE
Update backend URL in config and CSP

### DIFF
--- a/frontend-nginx.conf
+++ b/frontend-nginx.conf
@@ -34,7 +34,7 @@ server {
     add_header X-Frame-Options "DENY" always;
     add_header X-XSS-Protection "1; mode=block" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.gpteng.co; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https://fortress-modeler-api-928130924917.australia-southeast2.run.app https://accounts.google.com https://www.googleapis.com;" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.gpteng.co; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https://fortress-modeler-backend-928130924917.australia-southeast2.run.app https://accounts.google.com https://www.googleapis.com;" always;
 
     # Health check endpoint for Cloud Run
     location /health {

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -16,7 +16,7 @@ export const config: AppConfig = {
   enableDemoData: import.meta.env.MODE === 'development' || import.meta.env.VITE_ENABLE_DEMO_DATA === 'true',
   enableAnalytics: import.meta.env.VITE_ENABLE_ANALYTICS === 'true',
   enableDevTools: import.meta.env.MODE === 'development',
-  apiUrl: import.meta.env.VITE_API_URL || 'https://fortress-modeler-api-928130924917.australia-southeast2.run.app',
+  apiUrl: import.meta.env.VITE_API_URL || 'https://fortress-modeler-backend-928130924917.australia-southeast2.run.app',
   googleClientId: import.meta.env.VITE_GOOGLE_CLIENT_ID || '928130924917-fcu6m854ua2ajutk3eu191okl4f29uqv.apps.googleusercontent.com',
   version: '1.0.0',
   useCloudSync: true // Re-enabled with proper UUID handling


### PR DESCRIPTION
## Summary
- point `apiUrl` fallback to the backend service
- update CSP `connect-src` for new backend hostname

## Testing
- `npm run lint` *(fails: 74 errors)*
- `npm run typecheck`
- `npm run build`
- ⚠️ `docker` not installed; container rebuild skipped

------
https://chatgpt.com/codex/tasks/task_b_685b8ff394988320a48336e1254ce021