### PR TITLE
Update backend URL

### DIFF
--- a/frontend-cloudbuild.yaml
+++ b/frontend-cloudbuild.yaml
@@ -9,7 +9,7 @@ steps:
     entrypoint: 'npm'
     args: ['run', 'build']
     env:
-      - 'VITE_API_URL=https://fortress-modeler-api-928130924917.australia-southeast2.run.app'
+      - 'VITE_API_URL=https://fortress-modeler-backend-928130924917.australia-southeast2.run.app'
       - 'VITE_GOOGLE_CLIENT_ID=928130924917-fcu6m854ua2ajutk3eu191okl4f29uqv.apps.googleusercontent.com'
       - 'VITE_ENABLE_DEMO_DATA=false'
       - 'VITE_ENABLE_ANALYTICS=false'

--- a/frontend-nginx.conf
+++ b/frontend-nginx.conf
@@ -34,7 +34,7 @@ server {
     add_header X-Frame-Options "DENY" always;
     add_header X-XSS-Protection "1; mode=block" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.gpteng.co; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https://fortress-modeler-api-928130924917.australia-southeast2.run.app https://accounts.google.com https://www.googleapis.com;" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.gpteng.co; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https://fortress-modeler-backend-928130924917.australia-southeast2.run.app https://accounts.google.com https://www.googleapis.com;" always;
 
     # Health check endpoint for Cloud Run
     location /health {

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -16,7 +16,7 @@ export const config: AppConfig = {
   enableDemoData: import.meta.env.MODE === 'development' || import.meta.env.VITE_ENABLE_DEMO_DATA === 'true',
   enableAnalytics: import.meta.env.VITE_ENABLE_ANALYTICS === 'true',
   enableDevTools: import.meta.env.MODE === 'development',
-  apiUrl: import.meta.env.VITE_API_URL || 'https://fortress-modeler-api-928130924917.australia-southeast2.run.app',
+  apiUrl: import.meta.env.VITE_API_URL || 'https://fortress-modeler-backend-928130924917.australia-southeast2.run.app',
   googleClientId: import.meta.env.VITE_GOOGLE_CLIENT_ID || '928130924917-fcu6m854ua2ajutk3eu191okl4f29uqv.apps.googleusercontent.com',
   version: '1.0.0',
   useCloudSync: true // Re-enabled with proper UUID handling


### PR DESCRIPTION
## Summary
- switch default API URL to `fortress-modeler-backend-928130924917.australia-southeast2.run.app`
- allow CSP to connect to the new backend
- deploy frontend build with new backend URL

## Testing
- `npm run lint` *(fails: Unexpected any, other lint errors)*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_b_685b8f759b548320824b08780ad335e4