### PR TITLE
Ensure project cards navigate even with stale state

### DIFF
--- a/src/pages/projects/ProjectsList.tsx
+++ b/src/pages/projects/ProjectsList.tsx
@@ -23,11 +23,15 @@ const ProjectsList = () => {
     : projects.filter(project => typeof project.id === 'number');
 
   const handleProjectClick = (projectId: number | string) => {
-    const project = availableProjects.find(p => p.id === projectId);
+    const project = availableProjects.find((p) => p.id === projectId);
     if (project) {
       setCurrentProject(project);
-      navigate(`/projects/${projectId}`);
+    } else {
+      console.warn(
+        `Project with id ${projectId} not found in local state. Navigation will still occur.`
+      );
     }
+    navigate(`/projects/${projectId}`);
   };
 
   return (


### PR DESCRIPTION
## Summary
- always navigate to ProjectDetail when clicking a card
- log a console warning if the local project is missing

## Testing
- `npm run lint` *(fails: unexpected any)*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_b_685b8f3d7888832096466d4a2e4d82ed