### PR TITLE
Fix navigation when project lookup fails

### DIFF
--- a/src/pages/projects/ProjectsList.tsx
+++ b/src/pages/projects/ProjectsList.tsx
@@ -26,8 +26,8 @@ const ProjectsList = () => {
     const project = availableProjects.find(p => p.id === projectId);
     if (project) {
       setCurrentProject(project);
-      navigate(`/projects/${projectId}`);
     }
+    navigate(`/projects/${projectId}`);
   };
 
   return (


### PR DESCRIPTION
## Summary
- ensure `handleProjectClick` always navigates

## Testing
- `npm run lint` *(fails: Unexpected any)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_b_685b8f740d0c8320a320882a4d17904a