### PR TITLE
Normalize server project fields

### DIFF
--- a/src/lib/normalizeProject.ts
+++ b/src/lib/normalizeProject.ts
@@ -1,0 +1,27 @@
+export const camelCaseKeys = <T = any>(input: any): T => {
+  if (Array.isArray(input)) {
+    return input.map((v) => camelCaseKeys(v)) as T;
+  }
+  if (input && typeof input === 'object') {
+    const result: any = {};
+    for (const [key, value] of Object.entries(input)) {
+      const camelKey = key.replace(/_([a-z])/g, (_, c) => c.toUpperCase());
+      result[camelKey] = camelCaseKeys(value);
+    }
+    return result;
+  }
+  return input as T;
+};
+
+export interface ServerProject {
+  [key: string]: any;
+}
+
+export type NormalizedProject = ReturnType<typeof camelCaseKeys>;
+
+export const normalizeProject = (project: ServerProject): NormalizedProject => {
+  return camelCaseKeys(project);
+};
+
+export const normalizeProjects = (projects: ServerProject[]): NormalizedProject[] =>
+  projects.map(normalizeProject);


### PR DESCRIPTION
## Summary
- add helper to convert snake_case project data to camelCase
- use normalization when fetching/creating/updating projects via `apiService`
- convert project lists returned from sync endpoints

## Testing
- `npm run lint` *(fails: Unexpected any, etc.)*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_b_685b8f3c099083209df0d0603e7bf79f