### PR TITLE
Handle UUID ids in local db helpers

### DIFF
--- a/src/components/models/ModelOverview.tsx
+++ b/src/components/models/ModelOverview.tsx
@@ -12,7 +12,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { Edit, Download, Share2 } from "lucide-react";
 import { useNavigate } from "react-router-dom";
-import { db } from "@/lib/db";
+import { db, getProject } from "@/lib/db";
 
 interface ModelOverviewProps {
   model: Model;
@@ -388,7 +388,7 @@ const ModelOverview = ({ model, projectId, actualsData = [] }: ModelOverviewProp
 
     try {
       // Get project data
-      const project = await db.projects.get(Number(projectId));
+      const project = await getProject(projectId as string | number);
       if (!project) {
         alert("Project not found.");
         return;

--- a/src/hooks/useProjects.ts
+++ b/src/hooks/useProjects.ts
@@ -89,7 +89,7 @@ export const useProject = (projectId: string | number | undefined) => {
         if (!project) throw new Error('Project not found');
         return project;
       }
-      const project = await storageService.getProjectLocal(Number(projectId));
+      const project = await storageService.getProjectLocal(projectId);
       if (!project) throw new Error('Project not found');
       return project;
     },
@@ -126,7 +126,7 @@ export const useUpdateProject = () => {
       if (typeof id === 'string' && id.includes('-') && isCloudEnabled()) {
         return apiService.updateProject(id, data);
       }
-      return storageService.updateProjectLocal(Number(id), data);
+      return storageService.updateProjectLocal(id, data);
     },
     onSuccess: (_, variables) => {
       queryClient.invalidateQueries({ queryKey: ['projects', 'my'] });
@@ -146,7 +146,7 @@ export const useDeleteProject = () => {
       if (typeof id === 'string' && id.includes('-') && isCloudEnabled()) {
         await apiService.deleteProject(id);
       } else {
-        await storageService.deleteProjectLocal(Number(id));
+        await storageService.deleteProjectLocal(id);
       }
     },
     onSuccess: () => {
@@ -169,7 +169,7 @@ export const useModelsForProject = (projectId: string | number | undefined) => {
       if (typeof projectId === 'string' && projectId.includes('-') && isCloudEnabled()) {
         return apiService.getModelsForProject(projectId);
       }
-      return storageService.getModelsForProjectLocal(Number(projectId));
+      return storageService.getModelsForProjectLocal(projectId);
     },
     enabled: !!projectId,
     staleTime: 5 * 60 * 1000,
@@ -204,7 +204,7 @@ export const useUpdateModel = () => {
       if (typeof id === 'string' && id.includes('-') && isCloudEnabled()) {
         return apiService.updateModel(id, data);
       }
-      return storageService.updateModelLocal(Number(id), data);
+      return storageService.updateModelLocal(id, data);
     },
     onSuccess: (_, variables) => {
       queryClient.invalidateQueries({ queryKey: ['models', variables.projectId] });
@@ -224,7 +224,7 @@ export const useDeleteModel = () => {
       if (typeof modelId === 'string' && modelId.includes('-') && isCloudEnabled()) {
         await apiService.deleteModel(modelId);
       } else {
-        await storageService.deleteModelLocal(Number(modelId));
+        await storageService.deleteModelLocal(modelId);
       }
     },
     onSuccess: (_, variables) => {

--- a/src/lib/hybrid-storage.ts
+++ b/src/lib/hybrid-storage.ts
@@ -1,13 +1,23 @@
-import { db, FinancialModel, Project, getActualsForProject } from './db';
+import {
+  db,
+  FinancialModel,
+  Project,
+  getProject,
+  updateProject,
+  deleteProject,
+  getModelsForProject,
+  getModelById,
+  addFinancialModel,
+  updateFinancialModel,
+  deleteFinancialModel,
+  getActualsForProject,
+} from './db';
 import { ActualsPeriodEntry } from '@/types/models';
-
-const isUUID = (id: string | number): id is string => 
-  typeof id === 'string' && id.includes('-') && id.length === 36;
 
 class HybridStorageService {
   // --- Project Methods ---
   async getProjectLocal(projectId: string | number): Promise<Project | undefined> {
-    return db.projects.get(Number(projectId));
+    return getProject(projectId);
   }
 
   async getAllProjectsLocal(): Promise<Project[]> {
@@ -20,24 +30,22 @@ class HybridStorageService {
   }
 
   async updateProjectLocal(projectId: string | number, projectData: Partial<Project>): Promise<Project> {
-    await db.projects.update(Number(projectId), projectData);
-    return (await db.projects.get(Number(projectId)))!;
+    await updateProject(projectId, projectData);
+    const updated = await getProject(projectId);
+    return updated!;
   }
 
   async deleteProjectLocal(projectId: string | number): Promise<void> {
-    await db.projects.delete(Number(projectId));
+    await deleteProject(projectId);
   }
 
   // --- Model Methods ---
   async getModelsForProjectLocal(projectId: string | number): Promise<FinancialModel[]> {
-    return db.financialModels.where('projectId').equals(Number(projectId)).toArray();
+    return getModelsForProject(projectId);
   }
 
   async getModelLocal(modelId: string | number): Promise<FinancialModel | undefined> {
-    if (isUUID(modelId)) {
-        return db.financialModels.where('uuid').equals(modelId).first();
-    }
-    return db.financialModels.get(Number(modelId));
+    return getModelById(modelId);
   }
 
   async createModelLocal(modelData: Partial<FinancialModel>): Promise<FinancialModel> {
@@ -46,32 +54,18 @@ class HybridStorageService {
   }
 
   async updateModelLocal(modelId: string | number, modelData: Partial<FinancialModel>): Promise<FinancialModel> {
-    if (isUUID(modelId)) {
-        const localModel = await db.financialModels.where('uuid').equals(modelId).first();
-        if (localModel?.id) {
-            await db.financialModels.update(localModel.id, modelData);
-            return (await db.financialModels.get(localModel.id))!;
-        }
-        throw new Error(`Model with UUID ${modelId} not found`);
-    }
-    await db.financialModels.update(Number(modelId), modelData);
-    return (await db.financialModels.get(Number(modelId)))!;
+    await updateFinancialModel(modelId, modelData);
+    const updated = await getModelById(modelId);
+    return updated!;
   }
 
   async deleteModelLocal(modelId: string | number): Promise<void> {
-    if (isUUID(modelId)) {
-        const localModel = await db.financialModels.where('uuid').equals(modelId).first();
-        if (localModel?.id) {
-            await db.financialModels.delete(localModel.id);
-        }
-    } else {
-        await db.financialModels.delete(Number(modelId));
-    }
+    await deleteFinancialModel(modelId);
   }
 
   // --- Actuals Methods ---
   async getActualsForProjectLocal(projectId: string | number): Promise<ActualsPeriodEntry[]> {
-    return getActualsForProject(Number(projectId));
+    return getActualsForProject(projectId);
   }
 
   // --- Backward Compatibility Aliases ---

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -50,3 +50,8 @@ export const formatDate = (date: Date | string | undefined | null): string => {
     day: 'numeric',
   });
 };
+
+export const isUUID = (id: string | number): id is string => {
+  const str = typeof id === 'string' ? id : '';
+  return /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/.test(str);
+};

--- a/src/pages/models/EditFinancialModel.tsx
+++ b/src/pages/models/EditFinancialModel.tsx
@@ -92,8 +92,8 @@ const EditFinancialModel = () => {
 
   if (model.assumptions.metadata?.type === "WeeklyEvent") {
     return (
-      <EventModelForm 
-        projectId={Number(projectId)}
+      <EventModelForm
+        projectId={projectId!}
         projectName={projectName}
         existingModel={model}
         onCancel={() => navigate(`/projects/${projectId}/models/${modelId}`)}

--- a/src/pages/models/NewFinancialModel.tsx
+++ b/src/pages/models/NewFinancialModel.tsx
@@ -200,9 +200,9 @@ const NewFinancialModel = () => {
   // Check if this is a weekly event project
   if (currentProject.productType === "WeeklyEvent") {
     return (
-      <EventModelForm 
-        projectId={Number(projectId)} 
-        projectName={currentProject.name} 
+      <EventModelForm
+        projectId={projectId!}
+        projectName={currentProject.name}
         onCancel={() => navigate(`/projects/${projectId}`)}
       />
     );


### PR DESCRIPTION
## Summary
- add `isUUID` helper
- handle UUID ids in `getProject`, `getModelsForProject`, `getActualsForProject`, `upsertActualsPeriod`, and model helpers
- refactor hybrid storage to use updated helpers
- remove Number casts in hooks and pages
- update model download to use `getProject`

## Testing
- `npm run lint` *(fails: 89 errors)*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_b_685e35fe257c8320955c8ee3e00e37d0