### PR TITLE
Remove redundant toast hook alias

### DIFF
--- a/src/components/ui/use-toast.ts
+++ b/src/components/ui/use-toast.ts
@@ -1,3 +1,0 @@
-import { useToast, toast } from "@/hooks/use-toast";
-
-export { useToast, toast };


### PR DESCRIPTION
## Summary
- delete duplicate `use-toast` alias
- keep the canonical toast hook under `src/hooks`

## Testing
- `npm run lint` *(fails: unexpected any)*
- `npm run build`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_b_685e36047d388320bd0fdd1bce09b446