### PR TITLE
Add variance table and conflict resolution

### DIFF
--- a/server/src/api/sync.routes.ts
+++ b/server/src/api/sync.routes.ts
@@ -218,15 +218,24 @@ router.post('/resolve-conflict', async (req: AuthRequest, res: Response) => {
       return;
     }
     
-    // TODO: Implement conflict resolution logic
-    // This would require storing conflicts in a separate table
-    // and implementing resolution strategies
-    
-    res.json({
-      message: 'Conflict resolution not yet implemented',
+    const resolved = await SyncService.resolveConflict(
+      req.userId,
       conflict_id,
-      resolution,
-      status: 'pending_implementation'
+      resolution as 'use_server' | 'use_client' | 'merge',
+      resolved_data
+    );
+
+    if (!resolved) {
+      res.status(404).json({
+        error: 'Conflict not found or already resolved',
+        code: 'CONFLICT_NOT_FOUND'
+      });
+      return;
+    }
+
+    res.json({
+      message: 'Conflict resolved',
+      conflict: resolved
     });
     
   } catch (error) {

--- a/server/src/db/schema.sql
+++ b/server/src/db/schema.sql
@@ -77,6 +77,22 @@ CREATE TABLE IF NOT EXISTS sync_events (
     resolved BOOLEAN DEFAULT false
 );
 
+-- Pending sync conflicts awaiting user resolution
+CREATE TABLE IF NOT EXISTS sync_conflicts (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    entity_type VARCHAR(50) NOT NULL,
+    entity_id UUID,
+    local_entity_id INTEGER,
+    local_data JSONB,
+    server_data JSONB,
+    local_timestamp TIMESTAMPTZ,
+    server_timestamp TIMESTAMPTZ,
+    resolution VARCHAR(20) DEFAULT 'pending', -- use_server, use_client, merge
+    resolved_data JSONB,
+    resolved_at TIMESTAMPTZ
+);
+
 -- Project sharing (for Phase 5, but create table now)
 CREATE TABLE IF NOT EXISTS project_shares (
     id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
@@ -98,6 +114,8 @@ CREATE INDEX IF NOT EXISTS idx_financial_models_local_id ON financial_models(loc
 CREATE INDEX IF NOT EXISTS idx_sync_events_user_id ON sync_events(user_id);
 CREATE INDEX IF NOT EXISTS idx_sync_events_entity ON sync_events(entity_type, entity_id);
 CREATE INDEX IF NOT EXISTS idx_sync_events_timestamp ON sync_events(timestamp_server);
+CREATE INDEX IF NOT EXISTS idx_sync_conflicts_user_id ON sync_conflicts(user_id);
+CREATE INDEX IF NOT EXISTS idx_sync_conflicts_entity ON sync_conflicts(entity_type, entity_id);
 CREATE INDEX IF NOT EXISTS idx_project_shares_project_id ON project_shares(project_id);
 CREATE INDEX IF NOT EXISTS idx_project_shares_email ON project_shares(shared_with_email);
 

--- a/server/src/services/sync.service.ts
+++ b/server/src/services/sync.service.ts
@@ -74,6 +74,13 @@ export interface ConflictItem {
   resolution_needed: 'manual' | 'auto_server' | 'auto_client';
 }
 
+export interface StoredConflict extends ConflictItem {
+  conflict_id: string;
+  resolution: 'pending' | 'use_server' | 'use_client' | 'merge';
+  resolved_data?: any;
+  resolved_at?: string;
+}
+
 export class SyncService {
   
   // Initialize sync status for user
@@ -178,6 +185,89 @@ export class SyncService {
     const result = await query(sql, values);
     return result.rows[0];
   }
+
+  // Store conflict record for later resolution
+  static async storeConflict(userId: string, conflict: ConflictItem): Promise<void> {
+    const sql = `
+      INSERT INTO sync_conflicts (
+        user_id, entity_type, entity_id, local_entity_id,
+        local_data, server_data, local_timestamp, server_timestamp
+      ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8);
+    `;
+    const values = [
+      userId,
+      conflict.type,
+      conflict.id || null,
+      conflict.local_id || null,
+      JSON.stringify(conflict.local_data || {}),
+      JSON.stringify(conflict.server_data || {}),
+      conflict.local_timestamp,
+      conflict.server_timestamp
+    ];
+    await query(sql, values);
+  }
+
+  static async resolveConflict(
+    userId: string,
+    conflictId: string,
+    resolution: 'use_server' | 'use_client' | 'merge',
+    resolvedData?: any
+  ): Promise<StoredConflict | null> {
+    // Fetch conflict
+    const result = await query(
+      'SELECT * FROM sync_conflicts WHERE id = $1 AND user_id = $2',
+      [conflictId, userId]
+    );
+    const conflict = result.rows[0];
+    if (!conflict || conflict.resolution !== 'pending') {
+      return null;
+    }
+
+    // Apply chosen resolution
+    if (resolution === 'use_client' || resolution === 'merge') {
+      const data = resolution === 'use_client' ? conflict.local_data : resolvedData;
+      if (conflict.entity_type === 'project') {
+        await ProjectService.upsertProject(userId, {
+          ...data,
+          id: conflict.entity_id,
+          local_id: conflict.local_entity_id,
+          updated_at: new Date()
+        });
+      } else if (conflict.entity_type === 'model') {
+        await FinancialModelService.upsertModel(userId, {
+          ...data,
+          id: conflict.entity_id,
+          local_id: conflict.local_entity_id,
+          updated_at: new Date()
+        });
+      }
+    }
+
+    const update = await query(
+      `UPDATE sync_conflicts
+         SET resolution = $1,
+             resolved_data = $2,
+             resolved_at = NOW()
+       WHERE id = $3 AND user_id = $4
+       RETURNING *;`,
+      [resolution, resolvedData ? JSON.stringify(resolvedData) : null, conflictId, userId]
+    );
+    const row = update.rows[0];
+    return {
+      conflict_id: row.id,
+      type: row.entity_type,
+      id: row.entity_id,
+      local_id: row.local_entity_id,
+      local_data: row.local_data,
+      server_data: row.server_data,
+      local_timestamp: row.local_timestamp,
+      server_timestamp: row.server_timestamp,
+      resolution_needed: 'manual',
+      resolution: row.resolution,
+      resolved_data: row.resolved_data,
+      resolved_at: row.resolved_at ? row.resolved_at.toISOString() : undefined
+    } as StoredConflict;
+  }
   
   // Process sync request
   static async processSync(userId: string, syncRequest: SyncRequest): Promise<SyncResponse> {
@@ -194,14 +284,15 @@ export class SyncService {
         for (const change of syncRequest.changes) {
           try {
             const changeResult = await this.processClientChange(
-              client, 
-              userId, 
-              change, 
+              client,
+              userId,
+              change,
               syncBatchId
             );
-            
+
             if (changeResult.conflict) {
               conflicts.push(changeResult.conflict);
+              await this.storeConflict(userId, changeResult.conflict);
             } else if (changeResult.serverChange) {
               processedChanges.push(changeResult.serverChange);
             }

--- a/src/components/models/PerformanceAnalysis.tsx
+++ b/src/components/models/PerformanceAnalysis.tsx
@@ -11,8 +11,9 @@ import {
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
 import { Label } from "@/components/ui/label";
 import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from 'recharts';
-import { formatCurrency, formatPercent } from "@/lib/utils";
+import { formatCurrency, formatPercent, formatVariance } from "@/lib/utils";
 import { VarianceCard } from '@/components/ui/VarianceCard';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 
 interface PerformanceAnalysisProps {
   financialModels: FinancialModel[];
@@ -461,10 +462,54 @@ export const PerformanceAnalysis: React.FC<PerformanceAnalysisProps> = ({
                            </ResponsiveContainer>
                         </div>
                      )}
+            </CardContent>
+            </Card>
+            {/* Category Variance Breakdown Table */}
+            <Card>
+                <CardHeader>
+                    <CardTitle className="text-lg font-semibold">Category Variance Breakdown</CardTitle>
+                </CardHeader>
+                <CardContent className="overflow-x-auto">
+                    <Table>
+                        <TableHeader>
+                            <TableRow>
+                                <TableHead>Category</TableHead>
+                                <TableHead className="text-right">Forecast</TableHead>
+                                <TableHead className="text-right">Revised</TableHead>
+                                <TableHead className="text-right">Variance</TableHead>
+                            </TableRow>
+                        </TableHeader>
+                        <TableBody>
+                            <TableRow>
+                                <TableCell>Total Revenue</TableCell>
+                                <TableCell className="text-right">{formatCurrency(totalRevenueForecast)}</TableCell>
+                                <TableCell className="text-right">{formatCurrency(revisedTotalRevenue)}</TableCell>
+                                <TableCell className="text-right">{formatVariance(totalRevenueVariance, totalRevenueForecast)}</TableCell>
+                            </TableRow>
+                            <TableRow>
+                                <TableCell>Total Costs</TableCell>
+                                <TableCell className="text-right">{formatCurrency(totalCostForecast)}</TableCell>
+                                <TableCell className="text-right">{formatCurrency(revisedTotalCost)}</TableCell>
+                                <TableCell className="text-right">{formatVariance(totalCostVariance, totalCostForecast)}</TableCell>
+                            </TableRow>
+                            <TableRow>
+                                <TableCell>Total Profit</TableCell>
+                                <TableCell className="text-right">{formatCurrency(totalProfitForecast)}</TableCell>
+                                <TableCell className="text-right">{formatCurrency(revisedTotalProfit)}</TableCell>
+                                <TableCell className="text-right">{formatVariance(totalProfitVariance, totalProfitForecast)}</TableCell>
+                            </TableRow>
+                            {isWeeklyEvent && (
+                                <TableRow>
+                                    <TableCell>Total Attendance</TableCell>
+                                    <TableCell className="text-right">{totalAttendanceForecast.toLocaleString()}</TableCell>
+                                    <TableCell className="text-right">{totalAttendanceActual.toLocaleString()}</TableCell>
+                                    <TableCell className="text-right">{formatVariance(totalAttendanceVariance, totalAttendanceForecast)}</TableCell>
+                                </TableRow>
+                            )}
+                        </TableBody>
+                    </Table>
                 </CardContent>
             </Card>
-
-            {/* TODO: Add Category Variance Breakdown Table */}
          </>
       )}
     </div>


### PR DESCRIPTION
## Summary
- show a Category Variance Breakdown table in performance analysis
- add sync conflict table and service helpers
- store conflicts during sync and resolve them via new endpoint

## Testing
- `npm run typecheck`
- `npm --prefix server install`
- `npm --prefix server run build`
- `npm run lint` *(fails: 88 errors)*

------
https://chatgpt.com/codex/tasks/task_b_685e36071b348320ad89dcc8778e26f3