### PR TITLE
Add event scheduling fields to new project form

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -3,3 +3,10 @@ export const productTypes = [
 ] as const;
 
 export type ProductType = typeof productTypes[number]['value'];
+
+export const eventTypes = [
+  { value: 'weekly', label: 'Weekly' },
+  { value: 'special', label: 'Special Event' }
+] as const;
+
+export type EventType = typeof eventTypes[number]['value'];


### PR DESCRIPTION
## Summary
- support event metadata in project constants
- extend NewProject form with event type and scheduling fields
- submit event scheduling data when creating a project

## Testing
- `npm run build`
- `npm test --silent` *(fails: Service 'IStorageService' is not registered)*

------
https://chatgpt.com/codex/tasks/task_b_6870a974bb508320944a73a1ea54de17