### PR TITLE
Update success_rating constraint

### DIFF
--- a/src/services/implementations/SupabaseStorageService.ts
+++ b/src/services/implementations/SupabaseStorageService.ts
@@ -667,6 +667,13 @@ export class SupabaseStorageService implements IStorageService {
       if (!actualData.project_id?.trim()) {
         throw new ValidationError('Project ID is required');
       }
+      if (
+        actualData.success_rating !== undefined &&
+        actualData.success_rating !== null &&
+        (actualData.success_rating < 1 || actualData.success_rating > 5)
+      ) {
+        throw new ValidationError('Success rating must be between 1 and 5');
+      }
       const newActual = {
         project_id: actualData.project_id,
         actual_fnb_revenue: actualData.actual_fnb_revenue || null,
@@ -701,6 +708,13 @@ export class SupabaseStorageService implements IStorageService {
       const existingActual = await this.getSpecialEventActual(actualId);
       if (!existingActual) {
         throw new NotFoundError(`Special event actual with ID ${actualId} not found`);
+      }
+      if (
+        actualData.success_rating !== undefined &&
+        actualData.success_rating !== null &&
+        (actualData.success_rating < 1 || actualData.success_rating > 5)
+      ) {
+        throw new ValidationError('Success rating must be between 1 and 5');
       }
       const updateData: any = {
         actual_fnb_revenue: actualData.actual_fnb_revenue,

--- a/supabase/migrations/20250711062225_change_success_rating_check.sql
+++ b/supabase/migrations/20250711062225_change_success_rating_check.sql
@@ -1,0 +1,9 @@
+-- Migration: 20250711062225_change_success_rating_check.sql
+-- Update success_rating constraint to limit values between 1 and 5
+
+ALTER TABLE public.special_event_actuals
+  DROP CONSTRAINT IF EXISTS special_event_actuals_success_rating_check;
+
+ALTER TABLE public.special_event_actuals
+  ADD CONSTRAINT special_event_actuals_success_rating_check
+  CHECK (success_rating IS NULL OR (success_rating >= 1 AND success_rating <= 5));


### PR DESCRIPTION
## Summary
- restrict `special_event_actuals.success_rating` to 1-5 via new migration
- validate success rating in SupabaseStorageService

## Testing
- `npm test` *(fails: Service 'IStorageService' is not registered)*

------
https://chatgpt.com/codex/tasks/task_b_6870ac83be88832087cfd97fe7ddce5f