### PR TITLE
Add special event project forms and milestone tracker

### DIFF
--- a/src/components/events/MilestoneTracker.tsx
+++ b/src/components/events/MilestoneTracker.tsx
@@ -1,0 +1,105 @@
+import React, { useState } from 'react';
+import {
+  useSpecialEventMilestones,
+  useCreateSpecialEventMilestone,
+  useUpdateSpecialEventMilestone,
+  useDeleteSpecialEventMilestone,
+} from '@/hooks/useProjects';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { format } from 'date-fns';
+
+interface MilestoneTrackerProps {
+  projectId: string;
+}
+
+export const MilestoneTracker: React.FC<MilestoneTrackerProps> = ({ projectId }) => {
+  const { data: milestones = [] } = useSpecialEventMilestones(projectId);
+  const createMilestone = useCreateSpecialEventMilestone();
+  const updateMilestone = useUpdateSpecialEventMilestone();
+  const deleteMilestone = useDeleteSpecialEventMilestone();
+
+  const [label, setLabel] = useState('');
+  const [targetDate, setTargetDate] = useState('');
+  const [notes, setNotes] = useState('');
+
+  const handleAdd = () => {
+    if (!label) return;
+    createMilestone.mutate({
+      project_id: projectId,
+      milestone_label: label,
+      target_date: targetDate ? new Date(targetDate) : undefined,
+      notes,
+    });
+    setLabel('');
+    setTargetDate('');
+    setNotes('');
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Event Milestones</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-4">
+          <div className="space-y-2">
+            <Input
+              placeholder="Milestone label"
+              value={label}
+              onChange={(e) => setLabel(e.target.value)}
+            />
+            <Input
+              type="date"
+              value={targetDate}
+              onChange={(e) => setTargetDate(e.target.value)}
+            />
+            <Textarea
+              placeholder="Notes"
+              value={notes}
+              onChange={(e) => setNotes(e.target.value)}
+            />
+            <Button onClick={handleAdd} size="sm" disabled={createMilestone.isPending}>
+              Add Milestone
+            </Button>
+          </div>
+          <div className="space-y-2">
+            {milestones.map((m) => (
+              <div key={m.id} className="border rounded p-2 flex items-start justify-between gap-2">
+                <div className="space-y-1">
+                  <p className="font-medium">{m.milestone_label}</p>
+                  {m.target_date && (
+                    <p className="text-sm text-muted-foreground">
+                      Target: {format(new Date(m.target_date), 'yyyy-MM-dd')}
+                    </p>
+                  )}
+                  {m.notes && <p className="text-sm text-muted-foreground">{m.notes}</p>}
+                </div>
+                <div className="flex items-center gap-2">
+                  <input
+                    type="checkbox"
+                    checked={m.completed}
+                    onChange={() =>
+                      updateMilestone.mutate({ id: m.id, data: { completed: !m.completed } })
+                    }
+                  />
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => deleteMilestone.mutate({ id: m.id, projectId })}
+                  >
+                    Delete
+                  </Button>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default MilestoneTracker;

--- a/src/components/events/SpecialEventActualForm.tsx
+++ b/src/components/events/SpecialEventActualForm.tsx
@@ -1,0 +1,138 @@
+import React, { useEffect } from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import {
+  useSpecialEventActuals,
+  useCreateSpecialEventActual,
+  useUpdateSpecialEventActual,
+} from '@/hooks/useProjects';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { sanitizeNumericInput, sanitizeTextInput } from '@/lib/security';
+
+interface SpecialEventActualFormProps {
+  projectId: string;
+}
+
+const actualSchema = z.object({
+  actual_fnb_revenue: z.number().min(0).optional(),
+  actual_fnb_cogs: z.number().min(0).optional(),
+  actual_merch_revenue: z.number().min(0).optional(),
+  actual_merch_cogs: z.number().min(0).optional(),
+  actual_sponsorship_income: z.number().min(0).optional(),
+  actual_ticket_sales: z.number().min(0).optional(),
+  actual_other_income: z.number().min(0).optional(),
+  actual_total_costs: z.number().min(0).optional(),
+  attendance: z.number().min(0).optional(),
+  success_rating: z.number().min(0).max(5).optional(),
+  notes: z.string().max(500).optional(),
+});
+
+type ActualFormData = z.infer<typeof actualSchema>;
+
+export const SpecialEventActualForm: React.FC<SpecialEventActualFormProps> = ({ projectId }) => {
+  const { data: actuals = [] } = useSpecialEventActuals(projectId);
+  const createActual = useCreateSpecialEventActual();
+  const updateActual = useUpdateSpecialEventActual();
+
+  const existing = actuals[0];
+
+  const form = useForm<ActualFormData>({
+    resolver: zodResolver(actualSchema),
+    defaultValues: {},
+  });
+
+  useEffect(() => {
+    if (existing) {
+      form.reset({
+        ...existing,
+      });
+    }
+  }, [existing, form]);
+
+  const onSubmit = (data: ActualFormData) => {
+    const sanitized: Partial<ActualFormData> = {
+      actual_fnb_revenue: data.actual_fnb_revenue ? sanitizeNumericInput(data.actual_fnb_revenue) : undefined,
+      actual_fnb_cogs: data.actual_fnb_cogs ? sanitizeNumericInput(data.actual_fnb_cogs) : undefined,
+      actual_merch_revenue: data.actual_merch_revenue ? sanitizeNumericInput(data.actual_merch_revenue) : undefined,
+      actual_merch_cogs: data.actual_merch_cogs ? sanitizeNumericInput(data.actual_merch_cogs) : undefined,
+      actual_sponsorship_income: data.actual_sponsorship_income ? sanitizeNumericInput(data.actual_sponsorship_income) : undefined,
+      actual_ticket_sales: data.actual_ticket_sales ? sanitizeNumericInput(data.actual_ticket_sales) : undefined,
+      actual_other_income: data.actual_other_income ? sanitizeNumericInput(data.actual_other_income) : undefined,
+      actual_total_costs: data.actual_total_costs ? sanitizeNumericInput(data.actual_total_costs) : undefined,
+      attendance: data.attendance ? sanitizeNumericInput(data.attendance) : undefined,
+      success_rating: data.success_rating ? sanitizeNumericInput(data.success_rating) : undefined,
+      notes: data.notes ? sanitizeTextInput(data.notes) : undefined,
+    };
+
+    if (existing) {
+      updateActual.mutate({ id: existing.id, data: sanitized });
+    } else {
+      createActual.mutate({ project_id: projectId, ...sanitized });
+    }
+  };
+
+  return (
+    <form onSubmit={form.handleSubmit(onSubmit)} aria-label="actual-form">
+      <Card>
+        <CardHeader>
+          <CardTitle>Special Event Actuals</CardTitle>
+        </CardHeader>
+        <CardContent className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div>
+            <label className="text-sm" htmlFor="actual_fnb_revenue">F&B Revenue</label>
+            <Input id="actual_fnb_revenue" type="number" step="any" {...form.register('actual_fnb_revenue', { valueAsNumber: true })} />
+          </div>
+          <div>
+            <label className="text-sm" htmlFor="actual_fnb_cogs">F&B COGS</label>
+            <Input id="actual_fnb_cogs" type="number" step="any" {...form.register('actual_fnb_cogs', { valueAsNumber: true })} />
+          </div>
+          <div>
+            <label className="text-sm" htmlFor="actual_merch_revenue">Merch Revenue</label>
+            <Input id="actual_merch_revenue" type="number" step="any" {...form.register('actual_merch_revenue', { valueAsNumber: true })} />
+          </div>
+          <div>
+            <label className="text-sm" htmlFor="actual_merch_cogs">Merch COGS</label>
+            <Input id="actual_merch_cogs" type="number" step="any" {...form.register('actual_merch_cogs', { valueAsNumber: true })} />
+          </div>
+          <div>
+            <label className="text-sm" htmlFor="actual_sponsorship_income">Sponsorship Income</label>
+            <Input id="actual_sponsorship_income" type="number" step="any" {...form.register('actual_sponsorship_income', { valueAsNumber: true })} />
+          </div>
+          <div>
+            <label className="text-sm" htmlFor="actual_ticket_sales">Ticket Sales</label>
+            <Input id="actual_ticket_sales" type="number" step="any" {...form.register('actual_ticket_sales', { valueAsNumber: true })} />
+          </div>
+          <div>
+            <label className="text-sm" htmlFor="actual_other_income">Other Income</label>
+            <Input id="actual_other_income" type="number" step="any" {...form.register('actual_other_income', { valueAsNumber: true })} />
+          </div>
+          <div>
+            <label className="text-sm" htmlFor="actual_total_costs">Total Costs</label>
+            <Input id="actual_total_costs" type="number" step="any" {...form.register('actual_total_costs', { valueAsNumber: true })} />
+          </div>
+          <div>
+            <label className="text-sm" htmlFor="attendance">Attendance</label>
+            <Input id="attendance" type="number" step="any" {...form.register('attendance', { valueAsNumber: true })} />
+          </div>
+          <div>
+            <label className="text-sm" htmlFor="success_rating">Success Rating (0-5)</label>
+            <Input id="success_rating" type="number" step="any" {...form.register('success_rating', { valueAsNumber: true })} />
+          </div>
+          <div className="md:col-span-2">
+            <label className="text-sm" htmlFor="actual_notes">Notes</label>
+            <Textarea id="actual_notes" {...form.register('notes')} />
+          </div>
+        </CardContent>
+      </Card>
+      <div className="mt-4">
+        <Button type="submit" disabled={createActual.isPending || updateActual.isPending}>Save Actuals</Button>
+      </div>
+    </form>
+  );
+};
+
+export default SpecialEventActualForm;

--- a/src/components/events/SpecialEventForecastForm.tsx
+++ b/src/components/events/SpecialEventForecastForm.tsx
@@ -1,0 +1,146 @@
+import React, { useEffect } from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import {
+  useSpecialEventForecasts,
+  useCreateSpecialEventForecast,
+  useUpdateSpecialEventForecast,
+} from '@/hooks/useProjects';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { sanitizeNumericInput, sanitizeTextInput } from '@/lib/security';
+
+interface SpecialEventForecastFormProps {
+  projectId: string;
+}
+
+const forecastSchema = z.object({
+  forecast_fnb_revenue: z.number().min(0).optional(),
+  forecast_fnb_cogs_pct: z.number().min(0).optional(),
+  forecast_merch_revenue: z.number().min(0).optional(),
+  forecast_merch_cogs_pct: z.number().min(0).optional(),
+  forecast_sponsorship_income: z.number().min(0).optional(),
+  forecast_ticket_sales: z.number().min(0).optional(),
+  forecast_other_income: z.number().min(0).optional(),
+  forecast_total_costs: z.number().min(0).optional(),
+  notes: z.string().max(500).optional(),
+});
+
+type ForecastFormData = z.infer<typeof forecastSchema>;
+
+export const SpecialEventForecastForm: React.FC<SpecialEventForecastFormProps> = ({
+  projectId,
+}) => {
+  const { data: forecasts = [] } = useSpecialEventForecasts(projectId);
+  const createForecast = useCreateSpecialEventForecast();
+  const updateForecast = useUpdateSpecialEventForecast();
+
+  const existing = forecasts[0];
+
+  const form = useForm<ForecastFormData>({
+    resolver: zodResolver(forecastSchema),
+    defaultValues: {},
+  });
+
+  useEffect(() => {
+    if (existing) {
+      form.reset({
+        ...existing,
+      });
+    }
+  }, [existing, form]);
+
+  const onSubmit = (data: ForecastFormData) => {
+    const sanitized: Partial<ForecastFormData> = {
+      forecast_fnb_revenue: data.forecast_fnb_revenue
+        ? sanitizeNumericInput(data.forecast_fnb_revenue)
+        : undefined,
+      forecast_fnb_cogs_pct: data.forecast_fnb_cogs_pct
+        ? sanitizeNumericInput(data.forecast_fnb_cogs_pct)
+        : undefined,
+      forecast_merch_revenue: data.forecast_merch_revenue
+        ? sanitizeNumericInput(data.forecast_merch_revenue)
+        : undefined,
+      forecast_merch_cogs_pct: data.forecast_merch_cogs_pct
+        ? sanitizeNumericInput(data.forecast_merch_cogs_pct)
+        : undefined,
+      forecast_sponsorship_income: data.forecast_sponsorship_income
+        ? sanitizeNumericInput(data.forecast_sponsorship_income)
+        : undefined,
+      forecast_ticket_sales: data.forecast_ticket_sales
+        ? sanitizeNumericInput(data.forecast_ticket_sales)
+        : undefined,
+      forecast_other_income: data.forecast_other_income
+        ? sanitizeNumericInput(data.forecast_other_income)
+        : undefined,
+      forecast_total_costs: data.forecast_total_costs
+        ? sanitizeNumericInput(data.forecast_total_costs)
+        : undefined,
+      notes: data.notes ? sanitizeTextInput(data.notes) : undefined,
+    };
+
+    if (existing) {
+      updateForecast.mutate({ id: existing.id, data: sanitized });
+    } else {
+      createForecast.mutate({ project_id: projectId, ...sanitized });
+    }
+  };
+
+  return (
+    <form onSubmit={form.handleSubmit(onSubmit)} aria-label="forecast-form">
+      <Card>
+        <CardHeader>
+          <CardTitle>Special Event Forecast</CardTitle>
+        </CardHeader>
+        <CardContent className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div>
+            <label className="text-sm" htmlFor="forecast_fnb_revenue">F&B Revenue</label>
+            <Input id="forecast_fnb_revenue" type="number" step="any" {...form.register('forecast_fnb_revenue', { valueAsNumber: true })} />
+          </div>
+          <div>
+            <label className="text-sm" htmlFor="forecast_fnb_cogs_pct">F&B COGS %</label>
+            <Input id="forecast_fnb_cogs_pct" type="number" step="any" {...form.register('forecast_fnb_cogs_pct', { valueAsNumber: true })} />
+          </div>
+          <div>
+            <label className="text-sm" htmlFor="forecast_merch_revenue">Merch Revenue</label>
+            <Input id="forecast_merch_revenue" type="number" step="any" {...form.register('forecast_merch_revenue', { valueAsNumber: true })} />
+          </div>
+          <div>
+            <label className="text-sm" htmlFor="forecast_merch_cogs_pct">Merch COGS %</label>
+            <Input id="forecast_merch_cogs_pct" type="number" step="any" {...form.register('forecast_merch_cogs_pct', { valueAsNumber: true })} />
+          </div>
+          <div>
+            <label className="text-sm" htmlFor="forecast_sponsorship_income">Sponsorship Income</label>
+            <Input id="forecast_sponsorship_income" type="number" step="any" {...form.register('forecast_sponsorship_income', { valueAsNumber: true })} />
+          </div>
+          <div>
+            <label className="text-sm" htmlFor="forecast_ticket_sales">Ticket Sales</label>
+            <Input id="forecast_ticket_sales" type="number" step="any" {...form.register('forecast_ticket_sales', { valueAsNumber: true })} />
+          </div>
+          <div>
+            <label className="text-sm" htmlFor="forecast_other_income">Other Income</label>
+            <Input id="forecast_other_income" type="number" step="any" {...form.register('forecast_other_income', { valueAsNumber: true })} />
+          </div>
+          <div>
+            <label className="text-sm" htmlFor="forecast_total_costs">Total Costs</label>
+            <Input id="forecast_total_costs" type="number" step="any" {...form.register('forecast_total_costs', { valueAsNumber: true })} />
+          </div>
+          <div className="md:col-span-2">
+            <label className="text-sm" htmlFor="forecast_notes">Notes</label>
+            <Textarea id="forecast_notes" {...form.register('notes')} />
+          </div>
+        </CardContent>
+      </Card>
+      <div className="mt-4">
+        <Button type="submit" disabled={createForecast.isPending || updateForecast.isPending}>
+          Save Forecast
+        </Button>
+      </div>
+    </form>
+  );
+};
+
+export default SpecialEventForecastForm;

--- a/src/components/events/__tests__/MilestoneTracker.test.tsx
+++ b/src/components/events/__tests__/MilestoneTracker.test.tsx
@@ -1,0 +1,57 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import userEvent from '@testing-library/user-event';
+import { render, screen } from '@/test/utils/test-utils';
+import { MilestoneTracker } from '../MilestoneTracker';
+import { setupServiceMocks } from '@/test/mocks/services';
+
+vi.mock('@/hooks/useProjects', () => ({
+  useSpecialEventMilestones: vi.fn(),
+  useCreateSpecialEventMilestone: vi.fn(),
+  useUpdateSpecialEventMilestone: vi.fn(),
+  useDeleteSpecialEventMilestone: vi.fn(),
+}));
+
+import * as mockHooks from '@/hooks/useProjects';
+
+describe('MilestoneTracker', () => {
+  let serviceMocks: ReturnType<typeof setupServiceMocks>;
+  let mockCreate: any;
+  let mockUpdate: any;
+  let mockDelete: any;
+
+  beforeEach(() => {
+    serviceMocks = setupServiceMocks();
+    mockCreate = vi.fn();
+    mockUpdate = vi.fn();
+    mockDelete = vi.fn();
+    mockHooks.useCreateSpecialEventMilestone.mockReturnValue({ mutate: mockCreate, isPending: false });
+    mockHooks.useUpdateSpecialEventMilestone.mockReturnValue({ mutate: mockUpdate, isPending: false });
+    mockHooks.useDeleteSpecialEventMilestone.mockReturnValue({ mutate: mockDelete, isPending: false });
+    mockHooks.useSpecialEventMilestones.mockReturnValue({ data: [], isLoading: false });
+  });
+
+  it('renders input fields', () => {
+    render(<MilestoneTracker projectId="p1" />);
+    expect(screen.getByPlaceholderText('Milestone label')).toBeInTheDocument();
+  });
+
+  it('adds a milestone', async () => {
+    const user = userEvent.setup();
+    render(<MilestoneTracker projectId="p1" />);
+    await user.type(screen.getByPlaceholderText('Milestone label'), 'Start');
+    await user.click(screen.getByRole('button', { name: /add milestone/i }));
+    expect(mockCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ project_id: 'p1', milestone_label: 'Start' })
+    );
+  });
+
+  it('toggles completion and deletes', async () => {
+    const user = userEvent.setup();
+    mockHooks.useSpecialEventMilestones.mockReturnValue({ data: [{ id: '1', project_id: 'p1', milestone_label: 'M1', completed: false }], isLoading: false });
+    render(<MilestoneTracker projectId="p1" />);
+    await user.click(screen.getByRole('checkbox'));
+    expect(mockUpdate).toHaveBeenCalledWith({ id: '1', data: { completed: true } });
+    await user.click(screen.getByRole('button', { name: /delete/i }));
+    expect(mockDelete).toHaveBeenCalledWith({ id: '1', projectId: 'p1' });
+  });
+});

--- a/src/components/events/__tests__/SpecialEventActualForm.test.tsx
+++ b/src/components/events/__tests__/SpecialEventActualForm.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import userEvent from '@testing-library/user-event';
+import { render, screen } from '@/test/utils/test-utils';
+import { SpecialEventActualForm } from '../SpecialEventActualForm';
+import { setupServiceMocks } from '@/test/mocks/services';
+
+vi.mock('@/hooks/useProjects', () => ({
+  useSpecialEventActuals: vi.fn(),
+  useCreateSpecialEventActual: vi.fn(),
+  useUpdateSpecialEventActual: vi.fn(),
+}));
+
+import * as mockHooks from '@/hooks/useProjects';
+
+describe('SpecialEventActualForm', () => {
+  let serviceMocks: ReturnType<typeof setupServiceMocks>;
+  let mockCreate: any;
+  let mockUpdate: any;
+
+  beforeEach(() => {
+    serviceMocks = setupServiceMocks();
+    mockCreate = vi.fn();
+    mockUpdate = vi.fn();
+    mockHooks.useCreateSpecialEventActual.mockReturnValue({ mutate: mockCreate, isPending: false });
+    mockHooks.useUpdateSpecialEventActual.mockReturnValue({ mutate: mockUpdate, isPending: false });
+    mockHooks.useSpecialEventActuals.mockReturnValue({ data: [], isLoading: false });
+  });
+
+  it('renders form fields', () => {
+    render(<SpecialEventActualForm projectId="p1" />);
+    expect(screen.getByLabelText('F&B Revenue')).toBeInTheDocument();
+    expect(screen.getByLabelText('Attendance')).toBeInTheDocument();
+  });
+
+  it('submits new actual', async () => {
+    const user = userEvent.setup();
+    render(<SpecialEventActualForm projectId="p1" />);
+    await user.type(screen.getByLabelText('F&B Revenue'), '123');
+    await user.click(screen.getByRole('button', { name: /save actuals/i }));
+    expect(mockCreate).toHaveBeenCalledWith(expect.objectContaining({ project_id: 'p1' }), expect.any(Object));
+  });
+
+  it('updates existing actual', async () => {
+    const user = userEvent.setup();
+    mockHooks.useSpecialEventActuals.mockReturnValue({ data: [{ id: '1', project_id: 'p1' }], isLoading: false });
+    render(<SpecialEventActualForm projectId="p1" />);
+    await user.click(screen.getByRole('button', { name: /save actuals/i }));
+    expect(mockUpdate).toHaveBeenCalledWith({ id: '1', data: expect.any(Object) });
+  });
+});

--- a/src/components/events/__tests__/SpecialEventForecastForm.test.tsx
+++ b/src/components/events/__tests__/SpecialEventForecastForm.test.tsx
@@ -1,0 +1,53 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import userEvent from '@testing-library/user-event';
+import { render, screen } from '@/test/utils/test-utils';
+import { SpecialEventForecastForm } from '../SpecialEventForecastForm';
+import { setupServiceMocks } from '@/test/mocks/services';
+
+vi.mock('@/hooks/useProjects', () => ({
+  useSpecialEventForecasts: vi.fn(),
+  useCreateSpecialEventForecast: vi.fn(),
+  useUpdateSpecialEventForecast: vi.fn(),
+}));
+
+import * as mockHooks from '@/hooks/useProjects';
+
+describe('SpecialEventForecastForm', () => {
+  let serviceMocks: ReturnType<typeof setupServiceMocks>;
+  let mockCreate: any;
+  let mockUpdate: any;
+
+  beforeEach(() => {
+    serviceMocks = setupServiceMocks();
+    mockCreate = vi.fn();
+    mockUpdate = vi.fn();
+    mockHooks.useCreateSpecialEventForecast.mockReturnValue({ mutate: mockCreate, isPending: false });
+    mockHooks.useUpdateSpecialEventForecast.mockReturnValue({ mutate: mockUpdate, isPending: false });
+    mockHooks.useSpecialEventForecasts.mockReturnValue({ data: [], isLoading: false });
+  });
+
+  it('renders form fields', () => {
+    render(<SpecialEventForecastForm projectId="proj" />);
+    expect(screen.getByLabelText('F&B Revenue')).toBeInTheDocument();
+    expect(screen.getByLabelText('Total Costs')).toBeInTheDocument();
+  });
+
+  it('submits new forecast', async () => {
+    const user = userEvent.setup();
+    render(<SpecialEventForecastForm projectId="proj" />);
+    await user.type(screen.getByLabelText('F&B Revenue'), '100');
+    await user.click(screen.getByRole('button', { name: /save forecast/i }));
+    expect(mockCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ project_id: 'proj' }),
+      expect.any(Object)
+    );
+  });
+
+  it('updates existing forecast', async () => {
+    const user = userEvent.setup();
+    mockHooks.useSpecialEventForecasts.mockReturnValue({ data: [{ id: '1', project_id: 'proj' }], isLoading: false });
+    render(<SpecialEventForecastForm projectId="proj" />);
+    await user.click(screen.getByRole('button', { name: /save forecast/i }));
+    expect(mockUpdate).toHaveBeenCalledWith({ id: '1', data: expect.any(Object) });
+  });
+});

--- a/src/pages/projects/ProjectDetail.tsx
+++ b/src/pages/projects/ProjectDetail.tsx
@@ -54,6 +54,9 @@ import { ShareProjectModal } from "@/components/projects/ShareProjectModal";
 import { isCloudModeEnabled } from "@/config/app.config";
 import { RiskAssessmentTab } from "@/components/risk/RiskAssessmentTab";
 import { useSupabaseAuth } from "@/hooks/useSupabaseAuth";
+import { SpecialEventForecastForm } from "@/components/events/SpecialEventForecastForm";
+import { SpecialEventActualForm } from "@/components/events/SpecialEventActualForm";
+import { MilestoneTracker } from "@/components/events/MilestoneTracker";
 
 // Loading component for lazy-loaded components
 const ComponentLoader = ({ message = "Loading..." }: { message?: string }) => (
@@ -300,22 +303,13 @@ const ProjectDetail = () => {
         {project.event_type === 'special' ? (
           <>
             <TabsContent value="forecast" className="space-y-4">
-              <Card>
-                <CardHeader><CardTitle>Special Event Forecast</CardTitle></CardHeader>
-                <CardContent><p className="text-muted-foreground">Special Event Forecast form will go here.</p></CardContent>
-              </Card>
+              <SpecialEventForecastForm projectId={project.id} />
             </TabsContent>
             <TabsContent value="actuals" className="space-y-4">
-              <Card>
-                <CardHeader><CardTitle>Special Event Actuals</CardTitle></CardHeader>
-                <CardContent><p className="text-muted-foreground">Special Event Actuals input form will go here.</p></CardContent>
-              </Card>
+              <SpecialEventActualForm projectId={project.id} />
             </TabsContent>
             <TabsContent value="milestones" className="space-y-4">
-              <Card>
-                <CardHeader><CardTitle>Event Milestones</CardTitle></CardHeader>
-                <CardContent><p className="text-muted-foreground">Special Event Milestones tracker will go here.</p></CardContent>
-              </Card>
+              <MilestoneTracker projectId={project.id} />
             </TabsContent>
           </>
         ) : (


### PR DESCRIPTION
## Summary
- add `SpecialEventForecastForm`, `SpecialEventActualForm` and `MilestoneTracker` components
- use hooks from `useProjects.ts` to load and mutate data
- integrate the new components in `ProjectDetail`
- provide unit tests for each new component

## Testing
- `npm test --silent` *(fails: Service 'IStorageService' is not registered)*

------
https://chatgpt.com/codex/tasks/task_b_6870ad7a8b048320b6cb19059dec1e00