### PR TITLE
Add unit and integration tests

### DIFF
--- a/src/hooks/__tests__/specialEventHooks.test.tsx
+++ b/src/hooks/__tests__/specialEventHooks.test.tsx
@@ -1,0 +1,129 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import {
+  useCreateProject,
+  useCreateSpecialEventForecast,
+  useCreateSpecialEventActual,
+  useUpdateSpecialEventMilestone
+} from '../useProjects'
+import { render } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { createTestQueryClient } from '@/test/utils/test-utils'
+import { setupServiceMocks } from '@/test/mocks/services'
+import { createProjectFixture } from '@/test/fixtures/projects'
+import type { SpecialEventForecast, SpecialEventActual, SpecialEventMilestone } from '@/lib/db'
+
+let serviceMocks: ReturnType<typeof setupServiceMocks>
+
+vi.mock('@/services/singleton', () => ({
+  getSupabaseStorageService: () => serviceMocks.storageService,
+  resetSupabaseStorageService: vi.fn(),
+}))
+
+const createWrapper = ({
+  initialEntries = ['/'],
+  queryClient = createTestQueryClient(),
+} = {}) => {
+  return ({ children }: { children: React.ReactNode }) => (
+    <MemoryRouter initialEntries={initialEntries}>
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    </MemoryRouter>
+  )
+}
+
+describe('special event hooks', () => {
+
+  beforeEach(() => {
+    serviceMocks = setupServiceMocks()
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.resetAllMocks()
+  })
+
+  it('should create a special event project', async () => {
+    const newProject = createProjectFixture({ event_type: 'special', event_date: new Date('2024-05-01') })
+    serviceMocks.storageService.createProject.mockResolvedValue(newProject)
+
+    const { result } = renderHook(() => useCreateProject(), {
+      wrapper: createWrapper(),
+    })
+
+    result.current.mutate({
+      name: newProject.name,
+      productType: newProject.productType,
+      event_type: 'special',
+      event_date: newProject.event_date,
+    })
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true)
+    })
+
+    expect(serviceMocks.storageService.createProject).toHaveBeenCalledWith(
+      expect.objectContaining({ event_type: 'special' })
+    )
+  })
+
+  it('should submit forecast form data', async () => {
+    const forecastData: Partial<SpecialEventForecast> = {
+      project_id: 'project1',
+      forecast_fnb_revenue: 1000,
+    }
+    const created = { id: 'forecast1', created_at: new Date(), ...forecastData } as SpecialEventForecast
+    serviceMocks.storageService.createSpecialEventForecast.mockResolvedValue(created)
+
+    const { result } = renderHook(() => useCreateSpecialEventForecast(), {
+      wrapper: createWrapper(),
+    })
+
+    result.current.mutate(forecastData)
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(serviceMocks.storageService.createSpecialEventForecast).toHaveBeenCalledWith(forecastData)
+  })
+
+  it('should submit actual form data', async () => {
+    const actualData: Partial<SpecialEventActual> = {
+      project_id: 'project1',
+      actual_fnb_revenue: 800,
+    }
+    const created = { id: 'actual1', created_at: new Date(), ...actualData } as SpecialEventActual
+    serviceMocks.storageService.createSpecialEventActual.mockResolvedValue(created)
+
+    const { result } = renderHook(() => useCreateSpecialEventActual(), {
+      wrapper: createWrapper(),
+    })
+
+    result.current.mutate(actualData)
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(serviceMocks.storageService.createSpecialEventActual).toHaveBeenCalledWith(actualData)
+  })
+
+  it('should update milestones', async () => {
+    const milestoneUpdate: Partial<SpecialEventMilestone> = {
+      milestone_label: 'Completed',
+      completed: true,
+    }
+    const updated = { id: 'milestone1', project_id: 'project1', ...milestoneUpdate } as SpecialEventMilestone
+    serviceMocks.storageService.updateSpecialEventMilestone.mockResolvedValue(updated)
+
+    const { result } = renderHook(() => useUpdateSpecialEventMilestone(), {
+      wrapper: createWrapper(),
+    })
+
+    result.current.mutate({ id: 'milestone1', data: milestoneUpdate })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(serviceMocks.storageService.updateSpecialEventMilestone).toHaveBeenCalledWith(
+      'milestone1',
+      milestoneUpdate
+    )
+  })
+})

--- a/src/test/e2e/app.test.ts
+++ b/src/test/e2e/app.test.ts
@@ -246,6 +246,23 @@ describe('Fortress Modeler E2E Tests', () => {
       
       await takeScreenshot(page, 'export-started')
     })
+
+    it('should generate an executive report', async () => {
+      const page = getPage()
+
+      await waitForApp(page)
+
+      await page.click('a[href="/settings"], [data-testid="nav-settings"]')
+
+      const downloadPromise = page.waitForEvent('download')
+
+      await page.click('button:has-text("Executive Report")')
+
+      const download = await downloadPromise
+      expect(download.suggestedFilename()).toMatch(/\.pdf$/)
+
+      await takeScreenshot(page, 'executive-report')
+    })
   })
 
   describe('Error Handling', () => {
@@ -285,6 +302,22 @@ describe('Fortress Modeler E2E Tests', () => {
       expect(errorMessages.length).toBeGreaterThan(0)
       
       await takeScreenshot(page, 'validation-errors')
+    })
+  })
+
+  describe('Calendar Display', () => {
+    it('should display date picker when selecting start date', async () => {
+      const page = getPage()
+
+      await waitForApp(page)
+
+      await page.click('[data-testid="new-project-button"], button:has-text("New Project")')
+
+      await page.click('label:has-text("Start Date") + div button')
+
+      await page.waitForSelector('.rdp', { timeout: 5000 })
+
+      await takeScreenshot(page, 'calendar-display')
     })
   })
 

--- a/src/test/mocks/services.ts
+++ b/src/test/mocks/services.ts
@@ -1,11 +1,18 @@
 import { vi } from 'vitest'
-import type { 
-  IStorageService, 
-  IErrorService, 
-  ILogService, 
-  IConfigService 
+import type {
+  IStorageService,
+  IErrorService,
+  ILogService,
+  IConfigService
 } from '@/services/interfaces'
-import type { Project, FinancialModel, ActualsPeriodEntry } from '@/lib/db'
+import type {
+  Project,
+  FinancialModel,
+  ActualsPeriodEntry,
+  SpecialEventForecast,
+  SpecialEventActual,
+  SpecialEventMilestone
+} from '@/lib/db'
 
 // Mock Storage Service
 export const createMockStorageService = (): IStorageService => ({
@@ -63,13 +70,30 @@ export const createMockStorageService = (): IStorageService => ({
 
   // Actuals methods
   getProjectActuals: vi.fn().mockResolvedValue([]),
-  upsertActuals: vi.fn().mockImplementation((actual: Omit<ActualsPeriodEntry, 'id'>) => 
+  upsertActuals: vi.fn().mockImplementation((actual: Omit<ActualsPeriodEntry, 'id'>) =>
     Promise.resolve({
       id: `mock-actual-${Date.now()}`,
       ...actual,
     } as ActualsPeriodEntry)
   ),
   deleteActuals: vi.fn().mockResolvedValue(undefined),
+
+  // Special Event methods
+  createSpecialEventForecast: vi
+    .fn()
+    .mockImplementation((forecast: Partial<SpecialEventForecast>) =>
+      Promise.resolve({ id: `mock-forecast-${Date.now()}`, ...forecast } as SpecialEventForecast)
+    ),
+  createSpecialEventActual: vi
+    .fn()
+    .mockImplementation((actual: Partial<SpecialEventActual>) =>
+      Promise.resolve({ id: `mock-se-actual-${Date.now()}`, ...actual } as SpecialEventActual)
+    ),
+  updateSpecialEventMilestone: vi
+    .fn()
+    .mockImplementation((id: string, updates: Partial<SpecialEventMilestone>) =>
+      Promise.resolve({ id, project_id: 'mock-project-id', ...updates } as SpecialEventMilestone)
+    ),
 
   // Utility methods
   clearAllData: vi.fn().mockResolvedValue(undefined),


### PR DESCRIPTION
## Summary
- add mock support for special event features
- test special-event hooks
- exercise report generation and calendar display in e2e suite

## Testing
- `npx vitest run src/hooks/__tests__/specialEventHooks.test.tsx` *(fails: Service 'IStorageService' is not registered)*

------
https://chatgpt.com/codex/tasks/task_b_6870ad7ff2208320ab41592bb4636613