### PR TITLE
Fix project event field updates

### DIFF
--- a/src/services/implementations/SupabaseStorageService.ts
+++ b/src/services/implementations/SupabaseStorageService.ts
@@ -187,6 +187,9 @@ export class SupabaseStorageService implements IStorageService {
       if (projectData.avatarImage !== undefined) updateData.avatar_image = projectData.avatarImage;
       if (projectData.is_public !== undefined) updateData.is_public = projectData.is_public;
       if (projectData.timeline !== undefined) updateData.timeline = this.mapTimelineToSupabase(projectData.timeline);
+      if (projectData.event_type !== undefined) updateData.event_type = projectData.event_type;
+      if (projectData.event_date !== undefined) updateData.event_date = projectData.event_date?.toISOString() || null;
+      if (projectData.event_end_date !== undefined) updateData.event_end_date = projectData.event_end_date?.toISOString() || null;
       
       // Merge additional data
       if (Object.keys(projectData).some(key => !['id', 'createdAt', 'updatedAt', 'name', 'description', 'productType', 'targetAudience', 'avatarImage', 'is_public', 'timeline'].includes(key))) {

--- a/src/services/implementations/__tests__/DexieStorageService.test.ts
+++ b/src/services/implementations/__tests__/DexieStorageService.test.ts
@@ -131,6 +131,27 @@ describe('DexieStorageService', () => {
       expect(result).toEqual(updatedProject)
     })
 
+    it('should update event fields on a project', async () => {
+      const updates = {
+        event_type: 'special' as const,
+        event_date: new Date('2024-05-01T00:00:00Z'),
+        event_end_date: new Date('2024-05-02T00:00:00Z'),
+      }
+      const updatedProject = createProjectFixture({ id: 'test-id', ...updates })
+
+      mockDb.projects.put.mockResolvedValue(1)
+      mockDb.projects.get.mockResolvedValue(updatedProject)
+
+      const result = await storageService.updateProject('test-id', updates)
+
+      expect(mockDb.projects.put).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'test-id', ...updates })
+      )
+      expect(result.event_type).toBe('special')
+      expect(result.event_date?.toISOString()).toBe(updates.event_date.toISOString())
+      expect(result.event_end_date?.toISOString()).toBe(updates.event_end_date.toISOString())
+    })
+
     it('should handle update project failure', async () => {
       mockDb.projects.put.mockResolvedValue(0)
 

--- a/src/services/implementations/__tests__/SupabaseStorageService.test.ts
+++ b/src/services/implementations/__tests__/SupabaseStorageService.test.ts
@@ -328,6 +328,53 @@ describe('SupabaseStorageService', () => {
         expect(result.description).toBe('Updated description');
       });
 
+      it('should update event fields successfully', async () => {
+        const existingProject = {
+          id: 'project-123',
+          name: 'Old Name',
+          product_type: 'SaaS',
+          user_id: 'user-123',
+          created_at: '2023-01-01T00:00:00Z',
+          updated_at: '2023-01-01T00:00:00Z',
+          description: null,
+          target_audience: null,
+          data: {},
+          timeline: {},
+          avatar_image: null,
+          is_public: false,
+          owner_email: 'test@example.com',
+          share_count: 0,
+          deleted_at: null,
+          event_type: 'weekly',
+          event_date: null,
+          event_end_date: null,
+        };
+
+        const updatedProject = {
+          ...existingProject,
+          event_type: 'special',
+          event_date: '2023-02-01T00:00:00.000Z',
+          event_end_date: '2023-02-05T00:00:00.000Z',
+        };
+
+        const getQueryBuilder = createMockQueryBuilder(existingProject);
+        const updateQueryBuilder = createMockQueryBuilder(updatedProject);
+
+        mockSupabase.from
+          .mockReturnValueOnce(getQueryBuilder)
+          .mockReturnValueOnce(updateQueryBuilder);
+
+        const result = await service.updateProject('project-123', {
+          event_type: 'special',
+          event_date: new Date('2023-02-01T00:00:00Z'),
+          event_end_date: new Date('2023-02-05T00:00:00Z'),
+        });
+
+        expect(result.event_type).toBe('special');
+        expect(result.event_date?.toISOString()).toBe('2023-02-01T00:00:00.000Z');
+        expect(result.event_end_date?.toISOString()).toBe('2023-02-05T00:00:00.000Z');
+      });
+
       it('should throw NotFoundError for non-existent project', async () => {
         const mockQueryBuilder = createMockQueryBuilder(null, { code: 'PGRST116' });
         mockSupabase.from.mockReturnValue(mockQueryBuilder);


### PR DESCRIPTION
## Summary
- map event fields in `SupabaseStorageService.updateProject`
- test event field updates in Dexie and Supabase storage services

## Testing
- `npm test` *(fails: Service 'IStorageService' is not registered)*

------
https://chatgpt.com/codex/tasks/task_b_6870af8ce8b48320bb4f9c404c7f2cc6